### PR TITLE
Allow generation of complete books of a single ability

### DIFF
--- a/elvenfire/artifacts/written.py
+++ b/elvenfire/artifacts/written.py
@@ -37,6 +37,7 @@ class _WrittenArtifact (_MultiAbilityArtifact):
         elif self.language != 'Common':
             self.value = round(self.value * 0.90)
 
+
 class Scroll (_WrittenArtifact):
 
     """A scroll, containing up to 5 mental abilities."""
@@ -81,6 +82,7 @@ class Book (_WrittenArtifact):
     def _numabilities(self):
         return bonus25()
 
+
 def CompleteBook(abilityname=None, maxIIQ=None, element=None, language=None):
 
     """ Create a book that contains exactly one ability in multiple levels, starting with IIQ 1.
@@ -100,10 +102,3 @@ def CompleteBook(abilityname=None, maxIIQ=None, element=None, language=None):
 
     maxability = PhysicalOrMentalAbility(abilityname, maxIIQ, element)
     return Book([force_level(maxability, iiq) for iiq in range(1, maxability.IIQ)] + [maxability], language)
-
-    """A book that contains exactly one ability in multiple levels, starting with IIQ 1.
-
-    By default, the ability will be chosen randomly, any physical or mental ability,
-    and the maximum IIQ included will be at least IIQ 3 (bonus5).
-
-    """

--- a/elvenfire/artifacts/written.py
+++ b/elvenfire/artifacts/written.py
@@ -1,3 +1,4 @@
+import copy
 import random
 
 from elvenfire import bonus5, bonus25
@@ -80,4 +81,29 @@ class Book (_WrittenArtifact):
     def _numabilities(self):
         return bonus25()
 
+def CompleteBook(abilityname=None, maxIIQ=None, element=None, language=None):
 
+    """ Create a book that contains exactly one ability in multiple levels, starting with IIQ 1.
+
+    By default, the ability will be chosen randomly, any physical or mental ability,
+    and the maximum IIQ included will be at least IIQ 3 (bonus5).
+
+    """
+
+    def force_level(maxability, IIQ):
+        ability = copy.deepcopy(maxability)
+        ability.IIQ = IIQ
+        return ability
+
+    if maxIIQ is None:
+        maxIIQ = max(3, bonus5())
+
+    maxability = PhysicalOrMentalAbility(abilityname, maxIIQ, element)
+    return Book([force_level(maxability, iiq) for iiq in range(1, maxability.IIQ)] + [maxability], language)
+
+    """A book that contains exactly one ability in multiple levels, starting with IIQ 1.
+
+    By default, the ability will be chosen randomly, any physical or mental ability,
+    and the maximum IIQ included will be at least IIQ 3 (bonus5).
+
+    """

--- a/testelvenfire/testwrittenartifacts.py
+++ b/testelvenfire/testwrittenartifacts.py
@@ -33,7 +33,7 @@ class TestScroll(unittest.TestCase):
         for language in languages:
             s = Scroll(language=language)
             self.assertEqual(s.language, language)
-            self.assert_(language in str(s))
+            self.assertTrue(language in str(s))
 
     def testinvalidlanguage(self):
         """Provide an invalid language, to generate an error."""
@@ -94,7 +94,7 @@ class TestBook(unittest.TestCase):
         for language in languages:
             s = Book(language=language)
             self.assertEqual(s.language, language)
-            self.assert_(language in str(s))
+            self.assertTrue(language in str(s))
             value = round(sum([a.AC for a in s.abilities]) / 10)
             if language == 'Common':
                 self.assertEqual(s.value, value)
@@ -112,6 +112,39 @@ class TestBook(unittest.TestCase):
         """Ensure that Books can be randomly generated without errors."""
         for i in range(100):
             Book()
+
+
+class TestCompleteBook(unittest.TestCase):
+
+    def testspecificbook(self):
+        """Create a fully specified complete book."""
+        book = CompleteBook('Storm', 5, 'Water', 'Hob/Goblin')
+        self.assertEqual(book.name,
+            "Book of (Storm: Water 1; Storm: Water 2; Storm: Water 3; Storm: Water 4; Storm: Water 5): Hob/Goblin")
+
+    def testinvalidability(self):
+        """Give an invalid ability name, to verify error."""
+        self.assertRaises(AbilityError, CompleteBook, "NotAnAbility")
+
+    def testinvalidIIQ(self):
+        """Give an invalid max IIQ, to verify error."""
+        self.assertRaises(AbilityError, CompleteBook, maxIIQ=10)
+
+    def testmaxIIQ(self):
+        """Give a max IIQ only, verify no errors."""
+        for i in range(100):
+            book = CompleteBook(maxIIQ=5)
+            self.assertEqual(len(book.abilities), 5)
+
+    def testrandom(self):
+        """Ensure a random book is never less than 3 abilities, and is always the same root ability and element."""
+        for i in range(100):
+            book = CompleteBook()
+            maxIIQ = len(book.abilities)
+            self.assertGreaterEqual(maxIIQ, 3)
+            sample = book.abilities[0]
+            expected = Book([PhysicalOrMentalAbility(sample.name, iiq, sample.element) for iiq in range(1, maxIIQ+1)], book.language)
+            self.assertEqual(book.name, expected.name)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Jace had a store in Guilderland that was exclusively this type of "everything you need to know about X" book. Those were all up to IIQ 5, but this up to IIQ 3-5 seemed like a reasonable cutoff to me. 🤷 Will add the store type in StoreManager as well for later reuse and to automate Guilderland updates...